### PR TITLE
Limit to one column when there are 20 or less results

### DIFF
--- a/gramdictru/Scripts/ApplicationState/index.tsx
+++ b/gramdictru/Scripts/ApplicationState/index.tsx
@@ -37,9 +37,17 @@ export class ApplicationState {
     @observable
     total = 0;
 
+    @observable
+    shortResultLimit = 20;
+
     @computed
     get canLoadMore() {
         return !this.reachedLimit && !this.isLoading;
+    }
+
+    @computed
+    get isShortResult() {
+        return this.shortResultLimit >= this.total;
     }
 
     callback?: () => void;

--- a/gramdictru/Scripts/ResultsBox/index.tsx
+++ b/gramdictru/Scripts/ResultsBox/index.tsx
@@ -24,7 +24,7 @@ export class ResultsBox extends React.Component<IResultBoxProps> {
                         scrollThreshold="0px"
                         key={this.props.applicationState.searchedTerm}>
                         {this.props.applicationState.results.map(resultSet => [
-                            <div className="results-table">
+                            <div className={"results-table" + (this.props.applicationState.isShortResult ? " short-results" : "")}>
                                 {resultSet.map(r => <div className="result-entry">
                         <div className="lemma" style={{textAlign: this.props.applicationState.searchTerm === "" || this.props.applicationState.searchTerm.startsWith('*') ? 'right' : 'left'}}>{r.lemma}</div>
                         <div className="symbol">{r.symbol}</div>

--- a/gramdictru/wwwroot/css/site.css
+++ b/gramdictru/wwwroot/css/site.css
@@ -33,6 +33,7 @@ body {
     display: inline-block;
     overflow-x: visible;
     margin-bottom: 50px;
+    width: 100%;
 }
 
 @media (max-width: 50em) {
@@ -352,12 +353,14 @@ a.contents-link {
 
 .results-table.short-results {
     column-count: 1;
+    column-width: auto;
+    max-width: 600px;
+    margin: 0 auto;
 }
 
 .result-entry {
     display: flex;
     break-inside: avoid;
-    width: 350px;
     margin: 0 auto;
 }
 

--- a/gramdictru/wwwroot/css/site.css
+++ b/gramdictru/wwwroot/css/site.css
@@ -350,6 +350,10 @@ a.contents-link {
     column-width: 350px;
 }
 
+.results-table.short-results {
+    column-count: 1;
+}
+
 .result-entry {
     display: flex;
     break-inside: avoid;


### PR DESCRIPTION
It appears that there is no reliable way of achieving this with CSS at the moment, there is a draft proposal from the W3C for doing this so I would imagine it would be possible in the future. For now I have forced the results into one column when there are 20 or less results
![image](https://user-images.githubusercontent.com/441023/52519536-4fd8e400-2c54-11e9-8210-7862af99def5.png)
![image](https://user-images.githubusercontent.com/441023/52519545-67b06800-2c54-11e9-9fc5-d9cb1a9f7297.png)
