### PR TITLE
flexibilize content

### DIFF
--- a/gramdictru/wwwroot/css/site.css
+++ b/gramdictru/wwwroot/css/site.css
@@ -398,11 +398,13 @@ a.contents-link {
     flex-direction: column;
     white-space: nowrap;
     padding-right: 0.5rem;
+	margin-right: 0.5rem;
     min-width: 1rem;
 }
 
 .grammar {
-    width: 55%;
+    flex-basis: 55%;
+	flex-shrink: 3;
     text-align: left;
     display: flex;
     flex-direction: column;

--- a/gramdictru/wwwroot/css/site.css
+++ b/gramdictru/wwwroot/css/site.css
@@ -398,13 +398,13 @@ a.contents-link {
     flex-direction: column;
     white-space: nowrap;
     padding-right: 0.5rem;
-	margin-right: 0.5rem;
+    margin-right: 0.5rem;
     min-width: 1rem;
 }
 
 .grammar {
     flex-basis: 55%;
-	flex-shrink: 3;
+    flex-shrink: 3;
     text-align: left;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
indirect "width" switched to more flexbox compatible attributes. (flex-basis and flex-shrink)
Result:
![da-layout-1](https://user-images.githubusercontent.com/50071892/57078109-4a8cb200-6cf6-11e9-8a82-08cf8594461d.png)
