### PR TITLE
Fixing super script positioning in header permalinks

### DIFF
--- a/gramdictru/wwwroot/css/site.css
+++ b/gramdictru/wwwroot/css/site.css
@@ -689,6 +689,21 @@ a.contents-link {
     margin-right: 2em;
 }
 
+.permalink:first-child ~ a {
+    position: relative;
+    bottom: 0.5em;
+    font-size: 0.8em;
+}
+
+h1:target .permalink,
+h2:target .permalink,
+h3:target .permalink,
+h4:target .permalink,
+h5:target .permalink,
+h6:target .permalink {
+    margin-right: 0;
+}
+
 .filter-wrapper {
     margin: 0 auto;
     color: white;


### PR DESCRIPTION
Closes #101 

The issue occurs because the footnotes are an <a> tag, which is then put into another <a> tag. As you can't have nested links, the browsers pull this out into a sibling <a> tag. One fix would be to ensure that all <sup> and <sub> are inside an <a> tag, until they can be updated I have added some CSS which should catch these cases.